### PR TITLE
Initialize/fetch submodules when creating sdist

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,6 +73,7 @@ jobs:
       git clone $(clone_url) $(checkout)
       cd $(checkout)
       git checkout $(commit)
+      git submodule update --init
     displayName: 'Checkout commit'
 
   - script: |


### PR DESCRIPTION
Encountered the issue that submodules as not fetched when building Cutlery with wheelwright.

I first wanted to condition the command to `.gitmodules` being available, but it seems that `git submodule update --init` even returns success when a repository does not have submodules.